### PR TITLE
Removes deepcopy of JHDBRecordInterface

### DIFF
--- a/record-sync-libraries/python/jh_recsynclib/db.py
+++ b/record-sync-libraries/python/jh_recsynclib/db.py
@@ -136,7 +136,8 @@ class JHDBRecordInterface(JHDBI):
             record_type = self.record_type
         dbc = self.get_cursor()
         dbc.execute(qry)
-        rec_factory = JHRecordFactory(record_type, db_handle=self.copy())
+        new_dbh = JHDBRecordInterface(self._app_name, record_type=self.record_type, table_map=self._table_map)
+        rec_factory = JHRecordFactory(record_type, db_handle=new_dbh)
         records = {rec_factory.create(row) for row in dbc.fetchall()}
         dbc.close()
         self.commit()

--- a/record-sync-libraries/python/setup.py
+++ b/record-sync-libraries/python/setup.py
@@ -17,7 +17,7 @@ import subprocess
 from setuptools import setup, find_packages
 
 # this should be pulled in automatically
-version = '0.1.0'
+version = '0.1.2'
 
 with open('README.md') as f:
     readme = f.read()


### PR DESCRIPTION
Python 3.6 copy.deepcopy now breaks on copying psycopg2.extensions.connection objects, this works around that